### PR TITLE
v2.5.1: suppress fullscreen prompt during gameplay, fix version drift

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -5,7 +5,8 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8d646e1b-c919-49d7-be40-5ef9960064bc")]
 
-// Version information - updated automatically by scripts from version.txt
-[assembly: AssemblyVersion("2.5.0")]
-[assembly: AssemblyFileVersion("2.5.0")]
-[assembly: AssemblyInformationalVersion("2.5.0")]
+// Version information - synced from version.txt by package_extension.ps1.
+// Edit version.txt (single source of truth), not these lines.
+[assembly: AssemblyVersion("2.5.1.0")]
+[assembly: AssemblyFileVersion("2.5.1.0")]
+[assembly: AssemblyInformationalVersion("2.5.1")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ControlUp Changelog
 
+## Version 2.5.1 (June 6, 2026)
+
+### No fullscreen prompt while a game is running
+
+- **Suppress prompt during gameplay**: ControlUp now tracks game start/stop and ignores controller connection events while a game is running. Connecting or reconnecting a controller mid-game (e.g. waking from sleep or re-pairing) no longer interrupts you with the switch-to-fullscreen prompt.
+- **Game state tracking**: Added handlers for Playnite's `OnGameStarted` / `OnGameStopped` events, logged when logging is enabled.
+- **Styling fixes**: Minor whitespace/formatting cleanup.
+
+Thanks to [@qoordination](https://github.com/qoordination) for contributing this release ([#5](https://github.com/aHuddini/ControlUp/pull/5)).
+
 ## Version 2.5.0 (April 11, 2026)
 
 ### Updated to Playnite SDK 6.16.0 & Extension Compatibility Notes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-2.5.0-blue.svg" alt="Version"> <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
+  <img src="https://img.shields.io/badge/version-2.5.1-blue.svg" alt="Version"> <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
 </p>
 
 <p align="center">
@@ -22,7 +22,11 @@ Includes the option to skip the pop-up to let the user directly switch to fullsc
 
 *Currently Tested on an Xbox Series X USB/Wireless Controller*
 
-## What's New in 2.5.0
+## What's New in 2.5.1
+
+- **No prompt during gameplay** — ControlUp now ignores controller connection events while a game is running, so reconnecting a controller mid-game (waking from sleep, re-pairing) no longer interrupts you with the switch-to-fullscreen prompt. Contributed by [@qoordination](https://github.com/qoordination) ([#5](https://github.com/aHuddini/ControlUp/pull/5)).
+
+Previously in 2.5.0:
 
 - **Playnite SDK 6.16.0** — Updated to the latest SDK (API 6.16.0, Playnite 10.52)
 - **Alternative fullscreen switch method** — Opt-in setting that uses Playnite's `--startfullscreen` CLI flag instead of launching `Playnite.FullscreenApp.exe` directly. Enable in Settings → Troubleshooting.

--- a/package_extension.ps1
+++ b/package_extension.ps1
@@ -33,6 +33,29 @@ $versionFull = (Get-Content $versionFile -Raw).Trim()
 # Convert version format: 1.0.0 -> 1_0_0 for filename
 $version = $versionFull -replace '\.', '_'
 
+# Sync AssemblyInfo.cs with version.txt (single source of truth).
+# AssemblyVersion/AssemblyFileVersion require 4 numeric parts (e.g. 2.5.1.0).
+$assemblyInfoPath = Join-Path $scriptDir "AssemblyInfo.cs"
+if (Test-Path $assemblyInfoPath) {
+    $asmContent = Get-Content $assemblyInfoPath -Raw
+    $asmVersion = if (($versionFull -replace '[^\.]','').Length -lt 3) { "$versionFull.0" } else { $versionFull }
+    $updatedAsm = $asmContent
+    $updatedAsm = $updatedAsm -replace 'AssemblyVersion\("[^"]*"\)',            "AssemblyVersion(`"$asmVersion`")"
+    $updatedAsm = $updatedAsm -replace 'AssemblyFileVersion\("[^"]*"\)',        "AssemblyFileVersion(`"$asmVersion`")"
+    $updatedAsm = $updatedAsm -replace 'AssemblyInformationalVersion\("[^"]*"\)', "AssemblyInformationalVersion(`"$versionFull`")"
+    if ($updatedAsm -ne $asmContent) {
+        Set-Content -Path $assemblyInfoPath -Value $updatedAsm -NoNewline
+        Write-Host "Synced AssemblyInfo.cs to version $versionFull" -ForegroundColor Yellow
+        Write-Host "  WARNING: AssemblyInfo.cs changed - rebuild before packaging so the DLL picks up the new version." -ForegroundColor Yellow
+        Write-Host "    dotnet build -c $Configuration" -ForegroundColor White
+        Write-Host ""
+    } else {
+        Write-Host "AssemblyInfo.cs already in sync with version $versionFull" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "WARNING: AssemblyInfo.cs not found - skipping version sync" -ForegroundColor Yellow
+}
+
 # Build paths
 $outputDir = "bin\$Configuration\net4.6.2"
 $packageDir = "package"
@@ -55,6 +78,24 @@ $dllInfo = Get-Item $dllPath
 Write-Host "Found DLL: $($dllInfo.Name)" -ForegroundColor Green
 Write-Host "  Size: $([math]::Round($dllInfo.Length/1KB, 2)) KB" -ForegroundColor Gray
 Write-Host "  Modified: $($dllInfo.LastWriteTime)" -ForegroundColor Gray
+
+# Verify the built DLL's embedded version matches version.txt (drift guard).
+# Catches the case where AssemblyInfo.cs was just synced but the project wasn't rebuilt.
+try {
+    $dllVersion = [System.Reflection.AssemblyName]::GetAssemblyName($dllInfo.FullName).Version
+    $expectedVersion = [Version]($asmVersion)
+    Write-Host "  Assembly version: $dllVersion" -ForegroundColor Gray
+    if ($dllVersion -ne $expectedVersion) {
+        Write-Host ""
+        Write-Host "ERROR: DLL version ($dllVersion) does not match version.txt ($expectedVersion)." -ForegroundColor Red
+        Write-Host "The build output is stale. Rebuild before packaging:" -ForegroundColor Yellow
+        Write-Host "  dotnet build -c $Configuration" -ForegroundColor White
+        Write-Host ""
+        exit 1
+    }
+} catch [System.Management.Automation.MethodInvocationException] {
+    Write-Host "  WARNING: Could not read DLL assembly version - skipping drift check" -ForegroundColor Yellow
+}
 Write-Host ""
 
 # Clean previous package


### PR DESCRIPTION
Bumps the project to **2.5.1** and finalizes the release docs for merged PR #5.

## What's included
- **AssemblyInfo.cs**: version `2.5.0` → `2.5.1`. The assembly metadata was stale — the DLL had been shipping `2.5.0` internally despite `extension.yaml`/`version.txt` saying `2.5.1`.
- **CHANGELOG.md / README.md**: 2.5.1 entry, version badge, and "What's New" — with credit to @qoordination for contributing the gameplay-prompt-suppression feature (#5).
- **package_extension.ps1**: permanently fixes the version drift —
  - syncs `AssemblyInfo.cs` from `version.txt` (single source of truth) on every package run
  - adds a **drift guard** that fails packaging if the built DLL's embedded version doesn't match `version.txt` (prevents shipping a stale binary)

## Verification
- Clean `dotnet build -c Release` → 0 warnings / 0 errors; DLL metadata confirmed `2.5.1.0`
- Packaging drift guard tested both ways: fails on mismatch (exit 1), passes when in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)